### PR TITLE
different way to get chromium revision from puppeteer package

### DIFF
--- a/downloader.js
+++ b/downloader.js
@@ -50,7 +50,7 @@ class Downloader {
      * @return {string}
      */
     static defaultRevision() {
-        return require(path.join(PROJECT_ROOT, 'package.json')).puppeteer.chromium_revision;
+        return require('puppeteer/lib/cjs/puppeteer/revisions.js').PUPPETEER_REVISIONS.chromium;
     }
 
     /**


### PR DESCRIPTION
hi all.
it seems that not much ppl are using the build.js but it seems that there was a change how one can get the revision from puppeteer and this sample here https://github.com/puppeteer/puppeteer/issues/8203#issuecomment-1109891159 is IMO a now working way to do it.

br, d