### PR TITLE
generated exe doesn't need hummus/binding folder next to server.exe artifact

### DIFF
--- a/build.js
+++ b/build.js
@@ -89,7 +89,7 @@ async function build() {
 
 async function createExecutables() {
     console.log('Create server executables');
-    await exec(['./src/server.js', '--out-path', buildPath]);
+    await exec(['.', '--out-path', buildPath, '--compress', 'GZip',]);
 }
 
 function mkDir(dir) {

--- a/package.json
+++ b/package.json
@@ -71,5 +71,8 @@
     "setupFiles": [
       "<rootDir>/__tests__/jest.setup.js"
     ]
+  },
+  "pkg": {
+    "assets": ["node_modules/hummus/binding/*"]
   }
 }


### PR DESCRIPTION
turning on gzip compression of exe file, making node_modules/hummus/binding path part of exe by adding it to the assets.

without content of node_modules/hummus/binding folder the exe will fail to run.